### PR TITLE
shrink docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+*.pyc
+**/__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM registry.cn-hangzhou.aliyuncs.com/miclon/py-nodejs:latest
-
+FROM registry.cn-hangzhou.aliyuncs.com/miclon/py-nodejs:latest as build
 WORKDIR /app
-# Install app dependencies
 COPY . /app
 RUN cd /app/web && pnpm install && pnpm run build
-RUN cp -r /app/web/dist /app/api/dist
-RUN cd /app/api && pip install -r requirements.txt
 
+FROM python:3.11-slim
+WORKDIR /app
+COPY api/requirements.txt /app/api/requirements.txt
+RUN pip install --no-cache-dir -r api/requirements.txt
+COPY --from=build /app/web/dist /app/api/dist
+COPY start.sh /app
+COPY api /app/api
 CMD ["/bin/bash", "start.sh"]


### PR DESCRIPTION
Thank you for sharing this impressive project!

I noticed that we are able to significantly reduce the size of the docker image by removing nodejs and node_modules, as well as switching to a lighter Python 3 base image. From 1.04GB, we are able to bring it down to just 192MB on localhost, and further compress it to 64.02MB, as show on the Docker Hub page:
- [xieyanbo/chatgpt-web:20230303-python3-slim](https://hub.docker.com/layers/xieyanbo/chatgpt-web/20230303-python3-slim/images/sha256-1d7f2cef97bfddad7dcfff145fbbc5f35d321c8582c9430d394f1f26be757cf0?context=explore)