### PR TITLE
新增openai接口地址动态修改

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist-ssr
 
 *.pyc
 **/__pycache__
+
+venv/

--- a/api/api.py
+++ b/api/api.py
@@ -1,67 +1,55 @@
-import os
-
-import httpx
-
-API_KEY = os.environ.get('API_KEY')
-if proxy := os.environ.get('HTTPS_PROXY'):
-    PROXIES = {"https://": proxy}
-else:
-    PROXIES = None
+import requests
 
 
 def check_api_key(func):
     def wrapper(*args, **kwargs):
-        api_key = kwargs.get('api_key', API_KEY) or API_KEY
+        api_key = kwargs.get('api_key', None)
+        base_url = kwargs.get('base_url', None)
         if not api_key:
-            raise ValueError('API key is required')
-        if not api_key.startswith('sk-'):
-            raise ValueError('API key must start with "sk-"')
+            raise ValueError('请配置API_KEY')
         kwargs['api_key'] = api_key
+        if not base_url:
+            base_url = 'https://api.openai.com'
+        kwargs['base_url'] = base_url
+        print(kwargs)
         return func(*args, **kwargs)
 
     return wrapper
 
 
 @check_api_key
-async def completions(message, api_key=None):
+def completions(message, api_key=None, base_url=None):
     """Get completions for the message."""
-    # print('message:', message)
-    url = "https://api.openai.com/v1/completions"
-    async with httpx.AsyncClient(proxies=PROXIES) as client:
-        response = await client.post(
-            url,
-            json=message.dict(),
-            headers={"Authorization": f"Bearer {api_key}"},
-            timeout=60,
-        )
-        # print('response:', response.json())
-        return response.json()
+    url = f"{base_url}/v1/completions"
+    response = requests.post(
+        url,
+        json=message.dict(),
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=60,
+    )
+    return response.json()
 
 
 @check_api_key
-async def completions_turbo(message, api_key=None):
+def completions_turbo(message, api_key=None, base_url=None):
     """Get completions for the message."""
-    # print('message:', message)
-    url = "https://api.openai.com/v1/chat/completions"
-    async with httpx.AsyncClient(proxies=PROXIES) as client:
-        response = await client.post(
-            url,
-            json=message.dict(),
-            headers={"Authorization": f"Bearer {api_key}"},
-            timeout=60,
-        )
-        # print('response:', response.json())
-        return response.json()
+    url = f"{base_url}/v1/chat/completions"
+    response = requests.post(
+        url,
+        json=message.dict(),
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=60,
+    )
+    return response.json()
 
 
 @check_api_key
-async def credit_summary(api_key=None):
+def credit_summary(api_key=None, base_url=None):
     """Get the credit summary for the API key."""
-    url = "https://api.openai.com/dashboard/billing/credit_grants"
-    async with httpx.AsyncClient(proxies=PROXIES) as client:
-        response = await client.get(
-            url,
-            headers={"Authorization": f"Bearer {api_key}"},
-            timeout=60,
-        )
-        return response.json()
+    url = f"{base_url}/dashboard/billing/credit_grants"
+    response = requests.get(
+        url,
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=60,
+    )
+    return response.json()

--- a/api/app.py
+++ b/api/app.py
@@ -44,21 +44,24 @@ async def root():
 @app.post("/completions")
 async def completions(request: Request, message: Message):
     api_key = request.headers.get('api_key')
-    res = await api.completions(message, api_key=api_key)
+    base_url = request.headers.get('base_url')
+    res = api.completions(message, api_key=api_key, base_url=base_url)
     return res
 
 
 @app.post("/completions_turbo")
 async def completions(request: Request, message: MessageTurbo):
     api_key = request.headers.get('api_key')
-    res = await api.completions_turbo(message, api_key=api_key)
+    base_url = request.headers.get('base_url')
+    res = api.completions_turbo(message, api_key=api_key, base_url=base_url)
     return res
 
 
 @app.get("/credit_summary")
 async def credit_summary(request: Request):
     api_key = request.headers.get('api_key')
-    res = await api.credit_summary(api_key=api_key)
+    base_url = request.headers.get('base_url')
+    res = api.credit_summary(api_key=api_key, base_url=base_url)
     return res
 
 

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -1,18 +1,17 @@
 import { getRequest, postRequest } from "./api";
 import useSetting from "@/composables/setting";
-import { TSummary } from '@/types'
 
-const setting = useSetting()
+const setting = useSetting();
 export const completion = async (model: string, text: string) => {
   const max_tokens_dict: { [key: string]: number } = {
-    'text-davinci-003': 4097,
-    'text-davinci-002': 4097,
-    'text-curie-001': 2048,
-    'text-babbage-001': 2048,
-    'text-ada-001': 2048,
-  }
+    "text-davinci-003": 4097,
+    "text-davinci-002": 4097,
+    "text-curie-001": 2048,
+    "text-babbage-001": 2048,
+    "text-ada-001": 2048,
+  };
   const res = await postRequest({
-    url: '/completions',
+    url: "/completions",
     data: {
       model: model,
       prompt: text,
@@ -20,35 +19,31 @@ export const completion = async (model: string, text: string) => {
       temperature: 0.9,
       frequency_penalty: 0,
       presence_penalty: 0,
-      stop: [
-        "\nAI:",
-        "\nUser:",
-      ]
+      stop: ["\nAI:", "\nUser:"],
     },
     headers: {
       api_key: setting.value.app_key,
-    }
-  })
-  return res
-}
+      base_url: setting.value.base_url,
+    },
+  });
+  return res;
+};
 
 export const completionTurbo = async (text: string) => {
   const res = await postRequest({
-    url: '/completions_turbo',
+    url: "/completions_turbo",
     data: {
-      model: 'gpt-3.5-turbo',
-      messages: [{ "role": "user", "content": text }],
-      stop: [
-        "\nAI:",
-        "\nUser:",
-      ]
+      model: "gpt-3.5-turbo",
+      messages: [{ role: "user", content: text }],
+      stop: ["\nAI:", "\nUser:"],
     },
     headers: {
       api_key: setting.value.app_key,
-    }
-  })
-  return res
-}
+      base_url: setting.value.base_url,
+    },
+  });
+  return res;
+};
 
 interface creditSummaryType {
   total_available: number;
@@ -58,9 +53,10 @@ interface creditSummaryType {
 
 export const creditSummary = async (): Promise<creditSummaryType> => {
   return await getRequest({
-    url: '/credit_summary',
+    url: "/credit_summary",
     headers: {
       api_key: setting.value.app_key,
-    }
-  })
-}
+      base_url: setting.value.base_url,
+    },
+  });
+};

--- a/web/src/components/setting.vue
+++ b/web/src/components/setting.vue
@@ -1,32 +1,38 @@
 <script setup lang="ts">
-import useSetting from '@/composables/setting'
-import { SettingOutlined } from '@ant-design/icons-vue'
+import useSetting from "@/composables/setting";
+import { SettingOutlined } from "@ant-design/icons-vue";
 
-const setting = useSetting()
-const models = ref(['text-davinci-003', 'text-davinci-002', 'text-curie-001', 'text-babbage-001', 'text-ada-001', 'gpt-3.5-turbo'])
+const setting = useSetting();
+const models = ref([
+  "gpt-3.5-turbo",
+  "gpt-4",
+]);
 
 const props = defineProps<{
-  visible: boolean
-}>()
+  visible: boolean;
+}>();
 
-const emit = defineEmits(['update:visible'])
+const emit = defineEmits(["update:visible"]);
 
 const visible = computed({
   get: () => props.visible,
-  set: value => emit('update:visible', value)
-})
+  set: (value) => emit("update:visible", value),
+});
 
 const handleOk = () => {
-  visible.value = false
-  window.location.reload()
-}
-
-
+  visible.value = false;
+  window.location.reload();
+};
 </script>
 
 <template>
   <div>
-    <a-modal v-model:visible="visible" @ok="handleOk" okText="确定" cancelText="关闭">
+    <a-modal
+      v-model:visible="visible"
+      @ok="handleOk"
+      okText="确定"
+      cancelText="关闭"
+    >
       <template #title>
         <SettingOutlined />
         <span class="ml-2">设置</span>
@@ -34,25 +40,38 @@ const handleOk = () => {
 
       <a-form :model="setting">
         <a-form-item label="API_KEY">
-          <a-input v-model:value="setting.app_key" placeholder="请输入API_KEY，以sk-开头的字符串" />
+          <a-input
+            v-model:value="setting.app_key"
+            placeholder="请输入API_KEY"
+          />
+        </a-form-item>
+        <a-form-item label="BASE_URL">
+          <a-input
+            v-model:value="setting.base_url"
+            placeholder="请输入BASE_URL，默认为api.openai.com"
+          />
         </a-form-item>
         <a-form-item label="连续对话">
-          <a-switch v-model:checked="setting.continuously" checked-children="开" un-checked-children="关" />
+          <a-switch
+            v-model:checked="setting.continuously"
+            checked-children="开"
+            un-checked-children="关"
+          />
         </a-form-item>
         <a-form-item label="对话模型">
-          <a-select ref="select" v-model:value="setting.model" style="width: 180px">
-            <a-select-option :value="model" v-for="model in models">{{ model }}</a-select-option>
+          <a-select
+            ref="select"
+            v-model:value="setting.model"
+            style="width: 180px"
+          >
+            <a-select-option :value="model" v-for="model in models">{{
+              model
+            }}</a-select-option>
           </a-select>
         </a-form-item>
       </a-form>
 
-
       <div class="mt-2"></div>
-
-
-
-
-
     </a-modal>
   </div>
 </template>

--- a/web/src/composables/setting.ts
+++ b/web/src/composables/setting.ts
@@ -1,18 +1,19 @@
-import { useStorage } from '@vueuse/core'
-
+import { useStorage } from "@vueuse/core";
 
 type Setting = {
-  app_key: string,
-  model: string,
-  continuously: boolean,
-}
+  app_key: string;
+  base_url: string;
+  model: string;
+  continuously: boolean;
+};
 
-const setting = useStorage<Setting>('setting', {
-  app_key: '',
-  model: 'text-davinci-003',
+const setting = useStorage<Setting>("setting", {
+  app_key: "",
+  base_url: "",
+  model: "gpt-3.5-turbo",
   continuously: false,
-})
+});
 
-const useSetting = () => setting
+const useSetting = () => setting;
 
-export default useSetting
+export default useSetting;


### PR DESCRIPTION
1、在设置弹窗中新增了一个接口地址的输入框，方便无法直接访问openai接口可以动态的修改为其他的代理地址。
2、去掉了key的校验规则，没有验证手机号可以通过openai的login接口获取到sess开头的token，可以替代sk开头的key，还可以查询余额
3、前端页面index.ts中在headers中新增base_url参数
4、去掉了从环境变量中读取参数得到代码